### PR TITLE
Updated jQuery CDN reference to v2.1.0 and v1.11.0

### DIFF
--- a/site/includes/headresources.hbs
+++ b/site/includes/headresources.hbs
@@ -6,7 +6,7 @@
 <!--[if lt IE 9]>
 <link rel="stylesheet" href="{{assets}}/css/ie8-wet-boew.css" />
 <link rel="stylesheet" href="{{assets}}/css/ie8-theme{{environment.suffix}}.css" />
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery{{environment.suffix}}.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery{{environment.suffix}}.js"></script>
 <script src="{{assets}}/js/ie8-wet-boew{{environment.suffix}}.js"></script>
 <![endif]-->
 


### PR DESCRIPTION
Note: v2.1.0 reference update taken care of by WET core.
