### PR TITLE
Build: Use tarball for upstream WET Bower dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "tests"
   ],
   "devDependencies": {
-	 "wet-boew": "git://github.com/wet-boew/wet-boew.git#v4.0"
+	 "wet-boew": "https://github.com/wet-boew/wet-boew/tarball/v4.0"
   },
   "resolutions": {
     "jquery": ">= 1.9.0"


### PR DESCRIPTION
Prevents fallback to last tagged version during bower install
