### PR TITLE
Bottom Leaf is cut in half

### DIFF
--- a/src/sass/views/_smallViewOver.scss
+++ b/src/sass/views/_smallViewOver.scss
@@ -18,7 +18,7 @@
 			> {
 				:before {
 					@extend %page-background;
-					background: transparent;
+					background: transparent!important;
 					content: " ";
 					margin: {
 						left: -15px;


### PR DESCRIPTION
Without the !important the leaf is cut in half.

On the working example. http://wet-boew.github.io/themes-dist/theme-gcwu-fegc/index-en.html

Before
![bottom-leaf-cut](https://cloud.githubusercontent.com/assets/4562025/2537826/e4783e28-b5b5-11e3-8531-05b7fff690f1.jpg)

After
![bottom-leaf-cut-fix](https://cloud.githubusercontent.com/assets/4562025/2537827/e959afee-b5b5-11e3-93b6-3be8b805e658.jpg)

Thank you
