### PR TITLE
Remove double border for multiple language site

### DIFF
--- a/src/sass/views/_mediumViewOver.scss
+++ b/src/sass/views/_mediumViewOver.scss
@@ -93,14 +93,10 @@ body {
 
 	ul {
 		li {
-			a {
-				border-right: 1px solid $gc-header-footer-divider-color;
-			}
-
 			&:last-child {
-				a {
-					border-right: 0;
-				}
+			a {
+				border-right: 0;
+			}
 			}
 		}
 	}


### PR DESCRIPTION
This should remove the double border when your site have more than 2 languages ( en, fr, es )

Look a this issue: https://github.com/wet-boew/theme-gcwu-fegc/issues/100
