### PR TITLE
[Markup] Removed the 'col-xs-6' from the markup from the French splash page.

### DIFF
--- a/site/pages/splashpage-fr.hbs
+++ b/site/pages/splashpage-fr.hbs
@@ -6,13 +6,13 @@
 }
 ---
 <h1>Bienvenue / <span lang="en">Welcome</span></h1>
-<section class="col-md-6 col-xs-6">
+<section class="col-md-6">
 	<h2>Boîte à outils de l’expérience Web</h2>
 	<a class="btn btn-lg btn-primary btn-block" href="../index-fr.html">Français</a>
 	<a class="btn btn-lg btn-default btn-block" href="../../Licence-fr.html" rel="license">Conditions régissant l'utilisation</a>
 </section>
 
-<section class="col-md-6 col-xs-6" lang="en">
+<section class="col-md-6" lang="en">
 	<h2>Web Experience Toolkit</h2>
 	<a class="btn btn-lg btn-primary btn-block" href="../index-en.html">English</a>
 	<a class="btn btn-lg btn-default btn-block" href="../../License-en.html" rel="license">Terms and conditions of use</a>


### PR DESCRIPTION
- Ensures the English and French markup are the same.
- Fixes https://github.com/wet-boew/theme-gcwu-fegc/issues/110
