### PR TITLE
[Print CSS] Set the print CSS for the page header elements.

### DIFF
--- a/src/views/_print.scss
+++ b/src/views/_print.scss
@@ -46,8 +46,23 @@
 	top: 0;
 }
 
+header {
+	.brand {
+		margin-bottom: 0;
+	}
+}
+
 #wb-bc {
+	.breadcrumb {
+		margin-bottom: 0;
+		padding-top: 0;
+	}
+	
 	a[href]:after {
 		content: "";
 	}
+}
+
+h1 {
+	margin-top: 0;
 }


### PR DESCRIPTION
To reduce the amount of space taken up by the document header when printing.
