### PR TITLE
Theme: Fixed header FIP image's alt text.

### DIFF
--- a/site/includes/headerbar.hbs
+++ b/site/includes/headerbar.hbs
@@ -3,7 +3,7 @@
 	"officiallanguage": "<%= language === 'en' || language === 'fr' %>"
 }
 ---
-<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-{{#is headerbar.officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" aria-label="{{{i18n "tmpl-gc-sig"}}}"></object>
+<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-{{#is headerbar.officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt headerbar.officiallanguage "true"}} lang="{{{site.defaultLanguage}}}"{{/isnt}}></object>
 <ul id="gc-bar" class="list-inline">
 {{#is headerbar.officiallanguage "true"}}
 	<li><a href="http://www.canada.ca/{{language}}/index.html" rel="external">Canada.ca</a></li>

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -1,4 +1,8 @@
-<!DOCTYPE html>
+---
+{
+	"officiallanguage": "<%= language === 'en' || language === 'fr' %>"
+}
+---<!DOCTYPE html>
 <!--[if lt IE 9]><html class="no-js lt-ie9" lang="{{language}}" dir="{{{i18n "lang-dir"}}}"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="{{language}}" dir="{{{i18n "lang-dir"}}}">
@@ -19,7 +23,7 @@
 			<div id="wb-bnr" class="row">
 				<div class="row">
 					<div class="col-sm-6">
-						<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{language}}.svg" aria-label="{{{i18n "tmpl-gc-sig"}}}"></object>
+						<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{language}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt officiallanguage "true"}} lang="{{site.defaultLanguage}}"{{/isnt}}></object>
 					</div>
 					<div class="col-sm-6">
 						<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-alt.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>

--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -17,7 +17,7 @@
 	<body vocab="http://schema.org/" typeof="WebPage">
 		<header role="banner">
 			<div id="wb-bnr" class="container">
-				<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{language}}.svg" aria-label="{{{i18n "tmpl-gc-sig"}}}"></object>
+				<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{language}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"></object>
 			</div>
 		</header>
 		<main role="main" property="mainContentOfPage" class="container">


### PR DESCRIPTION
A bilingual FIP image is situated in the top-right of all of the usability theme's pages. Until now, in all standard/server message/splash page templates, the image's alt text was unilingual and based on the current page language. However, that wasn't an accurate representation of the text in the image.

This commit adds extra handlebars conditions to make the FIP's alt text bilingual depending on the current page language. In French pages, it'll be represented as French/English bilingual text. In all other pages, it'll be represented as English/French bilingual text. Furthermore, in multilingual pages, a lang="en" attribute will be added to the image's object element in order to assist screen readers.

Related to wet-boew/GCWeb#1241.