### PR TITLE
Server message pages: Fixed FIP image references in i18n pages.

### DIFF
--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -23,7 +23,7 @@
 			<div id="wb-bnr" class="row">
 				<div class="row">
 					<div class="col-sm-6">
-						<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{language}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt officiallanguage "true"}} lang="{{site.defaultLanguage}}"{{/isnt}}></object>
+						<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{#is officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt officiallanguage "true"}} lang="{{site.defaultLanguage}}"{{/isnt}}></object>
 					</div>
 					<div class="col-sm-6">
 						<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-alt.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>


### PR DESCRIPTION
The bilingual GC FIP image was previously not appearing in any multilingual server message page templates. They were setup to reference language-specific versions of the FIP image (which don't exist).

This commit modifies the multilingual versions of the aforementioned pages to use the English/French FIP image. English and French server message page templates will continue to use their respective variants of the FIP image.