### PR TITLE
Build: Excluded 'image' from no-misspelled-properties in sass-lint's settings.

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -31,6 +31,7 @@ rules:
       - 2
       -
           'extra-properties':
+              - 'image'
               - 'overflow-scrolling'
   no-url-protocols: 1
   no-trailing-whitespace: 2


### PR DESCRIPTION
This change works around sasstools/sass-lint#1158 to prevent the usability theme's dist builds from failing on [line 54 of src/variables.scss](https://github.com/wet-boew/theme-gcwu-fegc/blob/e57fd40440ceb17a02c46a2592bfd2c71192cc97/src/_variables.scss#L54).

**PS:** I'd recommend only merging this in if sasstools/sass-lint#1158 hasn't been resolved prior to WET v4.0.27's release date. If it's decided to merge this in, "[Do not merge]" should be removed from its subject prior to merging.