### PR TITLE
Theme: Reference SVG logos with img element instead of object.

### DIFF
--- a/site/includes/headerbar.hbs
+++ b/site/includes/headerbar.hbs
@@ -3,7 +3,7 @@
 	"officiallanguage": "<%= language === 'en' || language === 'fr' %>"
 }
 ---
-<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-{{#is headerbar.officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt headerbar.officiallanguage "true"}} lang="{{{site.defaultLanguage}}}"{{/isnt}}></object>
+<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-{{#is headerbar.officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" alt="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt headerbar.officiallanguage "true"}} lang="{{{site.defaultLanguage}}}"{{/isnt}} />
 <ul id="gc-bar" class="list-inline">
 {{#is headerbar.officiallanguage "true"}}
 	<li><a href="http://www.canada.ca/{{language}}/index.html" rel="external">Canada.ca</a></li>

--- a/site/includes/wordmark.hbs
+++ b/site/includes/wordmark.hbs
@@ -1,1 +1,1 @@
-<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
+<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -23,10 +23,10 @@
 			<div id="wb-bnr" class="row">
 				<div class="row">
 					<div class="col-sm-6">
-						<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{#is officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt officiallanguage "true"}} lang="{{site.defaultLanguage}}"{{/isnt}}></object>
+						<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-alt-{{#is officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" alt="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt officiallanguage "true"}} lang="{{site.defaultLanguage}}"{{/isnt}} />
 					</div>
 					<div class="col-sm-6">
-						<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-alt.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
+						<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-alt.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />
 					</div>
 				</div>
 			</div>

--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -17,7 +17,7 @@
 	<body vocab="http://schema.org/" typeof="WebPage">
 		<header role="banner">
 			<div id="wb-bnr" class="container">
-				<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-alt-{{language}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"></object>
+				<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-alt-{{language}}.svg" alt="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}" />
 			</div>
 		</header>
 		<main role="main" property="mainContentOfPage" class="container">
@@ -26,7 +26,7 @@
 			</div>
 		</main>
 		<footer role="contentinfo" class="container">
-			<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-alt.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
+			<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-alt.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />
 		</footer>
 		{{>footerresources}}
 		{{#if environment.test}}{{>test}}{{/if}}

--- a/src/assets/sig-en.svg
+++ b/src/assets/sig-en.svg
@@ -5,7 +5,10 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#F00;}
-			@media screen {.fip_text, .fip_flag {fill: #FFF;}}
+			@media screen and (-ms-high-contrast: none),
+			screen and (-ms-high-contrast: active) {
+				.fip_text, .fip_flag {fill: #FFF;}
+			}
 		</style>
 	</defs>
 	<g id="sig" transform="translate(-2,-2)">

--- a/src/assets/sig-fr.svg
+++ b/src/assets/sig-fr.svg
@@ -5,7 +5,10 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#F00;}
-			@media screen {.fip_text, .fip_flag {fill: #FFF;}}
+			@media screen and (-ms-high-contrast: none),
+			screen and (-ms-high-contrast: active) {
+				.fip_text, .fip_flag {fill: #FFF;}
+			}
 		</style>
 	</defs>
 	<g id="sig" transform="translate(-2,-2)">

--- a/src/assets/wmms.svg
+++ b/src/assets/wmms.svg
@@ -5,7 +5,10 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#F00;}
-			@media screen {.fip_text, .fip_flag {fill: #FFF;}}
+			@media screen and (-ms-high-contrast: none),
+			screen and (-ms-high-contrast: active) {
+				.fip_text, .fip_flag {fill: #FFF;}
+			}
 		</style>
 	</defs>
 	<g id="wmms" transform="translate(-1, -1)">

--- a/src/servermessage/_screen.scss
+++ b/src/servermessage/_screen.scss
@@ -13,6 +13,13 @@
 	height: 1.5em;
 }
 
+img {
+	&#gcwu-sig,
+	&#wmms {
+		margin-bottom: .375em;
+	}
+}
+
 #wmms {
 	float: right;
 }

--- a/src/splash/_screen.scss
+++ b/src/splash/_screen.scss
@@ -12,6 +12,10 @@
 	height: 1.5em;
 }
 
+img#gcwu-sig {
+	margin-bottom: .375em;
+}
+
 #wmms {
 	float: right;
 	height: 2.1em;

--- a/src/views/_screen.scss
+++ b/src/views/_screen.scss
@@ -12,6 +12,10 @@
 	height: 1.5em;
 }
 
+%theme-base-screen-brightness-0-invert-100 {
+	filter: brightness(0) invert(100%);
+}
+
 %all-view-navigation-links {
 	@include navigation-links;
 }
@@ -48,11 +52,13 @@
 
 #gcwu-sig {
 	@extend %fip-height;
+	@extend %theme-base-screen-brightness-0-invert-100;
 	margin: 10px 0;
 }
 
 #wmms {
 	@extend %fip-height;
+	@extend %theme-base-screen-brightness-0-invert-100;
 }
 
 #wb-sttl {


### PR DESCRIPTION
* Port of wet-boew/wet-boew#8282.
* Related to wet-boew/wet-boew#8276.
* Adds a CSS filter to change the signature/wordmark SVGs' colours to white in screen views:
  * Needed for Gecko, Blink and possibly Webkit due to their buggy handling of inline SVG media queries when the img element is used. When printing, they apply screen-only queries and ignore print-only queries.
  * Prevents the fallback PNG logos from being coloured white when printing in browsers that support CSS filters.
* Modifies the signature/wordmark SVGs' inline media queries to only change their colours to white in Internet Explorer 10-11 screen views:
  * Since IE10-11 correctly handle the aforementioned media queries but lack support for CSS filters, this is the most viable setup to make the signature/wordmark render correctly in all of WET's supported browsers.
* Modifies SCSS to increase the bottom margins on the signature/wordmark images to replicate the empty space that was previously appearing below their object element containers.
* Prevents the signature/wordmark SVGs from disappearing in Blink and possibly Webkit's print views in certain page templates.